### PR TITLE
fix(install): resolve PowerShell installer HTML-encoding parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <div align="right">
-
 [English](README.md) | [中文](README.zh-CN.md)
-
 </div>
 
 # okf — Open Knowledge Format
@@ -27,8 +25,13 @@ curl -fsSL https://raw.githubusercontent.com/superops-team/okf/main/scripts/inst
 **Windows (PowerShell):**
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1 | iex
 ```
+
+> If the one-liner fails with `Unexpected token` / `&#34;` parse errors (caused by proxies HTML-encoding the response), use the download-then-run method:
+> ```powershell
+> iwr -useb "https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1" -OutFile install.ps1; .\install.ps1
+> ```
 
 The installer:
 - Automatically detects your OS (Linux / macOS) and CPU architecture (amd64 / arm64)
@@ -140,7 +143,6 @@ timestamp: "2024-01-15T10:30:00Z"
 ---
 
 ## Users Table
-
 Stores all user account information.
 ```
 
@@ -203,7 +205,5 @@ Apache 2.0
 ---
 
 <div align="center">
-
 [⬆ Back to Top](#okf--open-knowledge-format) &nbsp;•&nbsp; [🇨🇳 切换到中文](README.zh-CN.md)
-
 </div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,5 @@
 <div align="right">
-
 [English](README.md) | [中文](README.zh-CN.md)
-
 </div>
 
 # okf — 开放知识格式 (Open Knowledge Format)
@@ -24,11 +22,16 @@
 curl -fsSL https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.sh | bash
 ```
 
-**Windows (PowerShell)：
+**Windows (PowerShell)：**
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1 | iex
 ```
+
+> 如果一行命令报 `Unexpected token` / `&#34;` 解析错误（通常是代理将响应做了 HTML 编码导致），请改用先下载再执行的方式：
+> ```powershell
+> iwr -useb "https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1" -OutFile install.ps1; .\install.ps1
+> ```
 
 安装脚本功能：
 - 自动检测操作系统（Linux / macOS / Windows）与 CPU 架构（amd64 / arm64）
@@ -117,7 +120,7 @@ okf hook -type post-commit
 ## 模块说明
 
 | 模块 | 路径 | 功能 |
-|------|------|------|
+|--------|------|------|
 | **okf** | pkg/okf/ | 核心类型定义（Concept, KnowledgeBundle）和公共 API |
 | **parser** | pkg/parser/ | Markdown + YAML frontmatter 解析和序列化 |
 | **query** | pkg/query/ | 高级查询构建器和匹配引擎 |
@@ -139,7 +142,6 @@ timestamp: "2024-01-15T10:30:00Z"
 ---
 
 ## 用户表
-
 存储所有用户账户信息。
 ```
 
@@ -202,7 +204,5 @@ Apache 2.0
 ---
 
 <div align="center">
-
 [⬆ 返回顶部](#okf--开放知识格式-open-knowledge-format) &nbsp;•&nbsp; [🇬🇧 Switch to English](README.md)
-
 </div>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2,20 +2,26 @@
 # Downloads pre-built binary from GitHub Releases
 #
 # Usage (PowerShell):
-#   iwr -useb https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1 | iex
-#   iwr -useb "https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1" -OutFile install.ps1; .\install.ps1 v1.2.0
+#   Recommended (avoids HTML-encoding pipe issues):
+#     irm https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1 | iex
+#   Alternative (download first, then execute):
+#     iwr -useb "https://raw.githubusercontent.com/superops-team/okf/main/scripts/install.ps1" -OutFile install.ps1; .\install.ps1
+#     .\install.ps1 v1.2.0
+#
+# If you see "Unexpected token" errors with &#34; in the message, your
+# network/proxy is HTML-encoding the raw response. Use the "download first"
+# method above, or run:  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 #
 # Environment variables:
 #   $env:OKF_VERSION    - specific version to install (default: latest)
 #   $env:OKF_INSTALL_DIR - install directory (default: $env:USERPROFILE\bin)
-
 param(
     [Parameter(Position = 0)]
     [string]$Version = ""
 )
-
 $ErrorActionPreference = "Stop"
-
+# Force TLS 1.2 for GitHub connections (older PowerShell defaults to TLS 1.0)
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -23,29 +29,25 @@ $GitHubRepo = "superops-team/okf"
 $BinaryName = "okf"
 $TmpDir     = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
 New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-function Write-Step($msg)    { Write-Host "  `" -ForegroundColor Cyan -NoNewline; Write-Host $msg }
-function Write-Ok($msg)      { Write-Host "  [OK] " -ForegroundColor Green -NoNewline; Write-Host $msg }
-function Write-Warn($msg)    { Write-Host "  [WARN] " -ForegroundColor Yellow -NoNewline; Write-Host $msg }
-function Write-Err($msg)     { Write-Host "  [ERR] " -ForegroundColor Red -NoNewline; Write-Host $msg }
-
+function Write-Step($msg)    { Write-Host '  >' -ForegroundColor Cyan -NoNewline; Write-Host " $msg" }
+function Write-Ok($msg)      { Write-Host '  [OK] ' -ForegroundColor Green -NoNewline; Write-Host $msg }
+function Write-Warn($msg)    { Write-Host '  [WARN] ' -ForegroundColor Yellow -NoNewline; Write-Host $msg }
+function Write-Err($msg)     { Write-Host '  [ERR] ' -ForegroundColor Red -NoNewline; Write-Host $msg }
 function Write-Banner {
     Write-Host ""
     Write-Host "okf - Open Knowledge Format Installer" -ForegroundColor Cyan
     Write-Host "=======================================" -ForegroundColor Cyan
     Write-Host ""
 }
-
 # ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
 Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {
     if ($TmpDir -and (Test-Path $TmpDir)) { Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue }
 } | Out-Null
-
 # ---------------------------------------------------------------------------
 # Detect OS / Arch
 # ---------------------------------------------------------------------------
@@ -60,7 +62,6 @@ function Detect-Arch {
         }
     }
 }
-
 # ---------------------------------------------------------------------------
 # Resolve latest version from GitHub API
 # ---------------------------------------------------------------------------
@@ -76,7 +77,6 @@ function Resolve-LatestVersion {
         exit 1
     }
 }
-
 # ---------------------------------------------------------------------------
 # Downloads a file with retry
 # ---------------------------------------------------------------------------
@@ -95,7 +95,6 @@ function Invoke-Download($Url, $Dest) {
         }
     } while ($true)
 }
-
 # ---------------------------------------------------------------------------
 # Verify SHA256 checksum
 # ---------------------------------------------------------------------------
@@ -126,7 +125,6 @@ function Verify-Checksum($AssetName, $ChecksumsFile) {
     }
     Write-Ok "Checksum verified (SHA256)"
 }
-
 # ---------------------------------------------------------------------------
 # Expand zip (native .NET 4.5+/PowerShell 5.1+ / pwsh)
 # ---------------------------------------------------------------------------
@@ -139,15 +137,12 @@ function Expand-Zip($Path, $Dest) {
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory($Path, $Dest)
 }
-
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 Write-Banner
-
 $arch = Detect-Arch
 Write-Step "Detected system: windows/$arch"
-
 # Resolve version: param -> env -> latest
 if ($Version) {
     $ver = $Version
@@ -159,24 +154,20 @@ if ($Version) {
 }
 $ver = $ver.TrimStart('v')
 Write-Step "Version: v$ver"
-
 $assetName = "$BinaryName`_$ver`_windows_$arch.zip"
 $downloadUrl = "https://github.com/$GitHubRepo/releases/download/v$ver/$assetName"
 $checksumsUrl = "https://github.com/$GitHubRepo/releases/download/v$ver/SHA256SUMS"
-
 # Download
 Push-Location $TmpDir
 try {
     Invoke-Download $downloadUrl (Join-Path $TmpDir $assetName)
     try { Invoke-Download $checksumsUrl (Join-Path $TmpDir "SHA256SUMS") } catch { Write-Warn "SHA256SUMS download failed" }
     Verify-Checksum $assetName (Join-Path $TmpDir "SHA256SUMS")
-
     Write-Step "Extracting archive..."
     Expand-Zip (Join-Path $TmpDir $assetName) $TmpDir
 } finally {
     Pop-Location
 }
-
 # Determine install dir
 if ($env:OKF_INSTALL_DIR) {
     $installDir = $env:OKF_INSTALL_DIR
@@ -184,19 +175,16 @@ if ($env:OKF_INSTALL_DIR) {
     $installDir = Join-Path $env:USERPROFILE "bin"
 }
 New-Item -ItemType Directory -Path $installDir -Force | Out-Null
-
 # Locate binary
 $binary = Get-ChildItem -Path $TmpDir -Filter "$BinaryName.exe" -Recurse | Select-Object -First 1 -ExpandProperty FullName
 if (-not $binary -or -not (Test-Path $binary)) {
     Write-Err "Could not find $BinaryName.exe in archive"
     exit 1
 }
-
 # Install
 $target = Join-Path $installDir "$BinaryName.exe"
 Copy-Item $binary $target -Force
 Write-Ok "Installed okf.exe to $target"
-
 # PATH check / addition
 if ($env:PATH -notlike "*$installDir*") {
     Write-Warn "$installDir is not in your PATH."
@@ -212,7 +200,6 @@ if ($env:PATH -notlike "*$installDir*") {
         Write-Step "Add it manually to your PATH: $installDir"
     }
 }
-
 Write-Host ""
 Write-Host "Installation complete!" -ForegroundColor Green
 Write-Host "  Run:  okf.exe --help"


### PR DESCRIPTION
The Windows one-liner 'iwr -useb <url> | iex' fails with 'Unexpected token' errors when proxies or network middleboxes HTML-encode the raw response, turning double-quotes into &#34; entities that PowerShell cannot parse.

Changes:
- Replace iwr|iex with irm|iex in README and script header (Invoke-RestMethod returns raw string content, avoiding WebResponseObject pipe encoding issues)
- Add download-then-run fallback method for users behind encoding proxies
- Force TLS 1.2 in the script for older PowerShell versions
- Replace backtick-escaped double-quotes in Write-Step with single-quoted strings to reduce parse fragility under partial HTML encoding
- Add troubleshooting note in script header

Closes #1