### PR TITLE
fix: two-round code review fixes for parser, MCP framing, v0.2 serialization

### DIFF
--- a/pkg/git/generator.go
+++ b/pkg/git/generator.go
@@ -763,7 +763,19 @@ func removeKnowledgeFile(knowledgeDir, resource string) {
 		path += ".md"
 	}
 	concept, err := parser.ParseConcept(path)
-	if err != nil || !hasTrustedGeneratedMetadata(concept.CustomFields, resource) {
+	if err != nil {
+		return
+	}
+	// Check both legacy boolean "generated" in CustomFields and v0.2 Generated struct.
+	trusted := hasTrustedGeneratedMetadata(concept.CustomFields, resource)
+	if !trusted && concept.Generated != nil {
+		if gen, ok := concept.CustomFields["generator"].(string); ok && gen == "okf.git" {
+			if sp, ok := concept.CustomFields["source_path"].(string); ok && (sp == resource || codeFileResource(sp) == resource) {
+				trusted = true
+			}
+		}
+	}
+	if !trusted {
 		return
 	}
 	_ = os.Remove(path)
@@ -787,8 +799,17 @@ func hasTrustedGeneratedMetadata(fields map[string]interface{}, sourcePath strin
 	if fields == nil {
 		return false
 	}
-	generated, ok := fields["generated"].(bool)
-	if !ok || !generated {
+	// Accept both legacy boolean form (generated: true) and v0.2 mapping form (generated: {by: ...}).
+	generatedOk := false
+	switch v := fields["generated"].(type) {
+	case bool:
+		generatedOk = v
+	case map[string]interface{}:
+		generatedOk = v != nil
+	default:
+		generatedOk = fields["generated"] != nil
+	}
+	if !generatedOk {
 		return false
 	}
 	generator, ok := fields["generator"].(string)
@@ -859,7 +880,7 @@ func SaveKnowledgeBase(bundle *okf.KnowledgeBundle, cfg *Config) (int, error) {
 			continue
 		}
 
-		content, err := parser.SerializeConcept(&parser.Concept{
+		pc := &parser.Concept{
 			Type:         concept.Type,
 			Title:        concept.Title,
 			Description:  concept.Description,
@@ -867,8 +888,51 @@ func SaveKnowledgeBase(bundle *okf.KnowledgeBundle, cfg *Config) (int, error) {
 			Tags:         concept.Tags,
 			Timestamp:    concept.Timestamp,
 			Content:      concept.Content,
+			FilePath:     concept.FilePath,
 			CustomFields: concept.CustomFields,
-		}, true)
+			Status:       string(concept.Status),
+			StaleAfter:   concept.StaleAfter,
+			Runtime:      concept.Runtime,
+			Computation:  concept.Computation,
+		}
+		if len(concept.Sources) > 0 {
+			pc.Sources = make([]parser.Source, len(concept.Sources))
+			for i, s := range concept.Sources {
+				pc.Sources[i] = parser.Source{
+					ID:           s.ID,
+					Resource:     s.Resource,
+					Title:        s.Title,
+					Author:       s.Author,
+					UsageCount:   s.UsageCount,
+					LastModified: s.LastModified,
+				}
+			}
+		}
+		if concept.UsageWindow != nil {
+			pc.UsageWindow = &parser.UsageWindow{From: concept.UsageWindow.From, To: concept.UsageWindow.To}
+		}
+		if concept.Generated != nil {
+			pc.Generated = &parser.GeneratedInfo{By: concept.Generated.By, At: concept.Generated.At}
+		}
+		if len(concept.Verified) > 0 {
+			pc.Verified = make([]parser.VerificationEvent, len(concept.Verified))
+			for i, v := range concept.Verified {
+				pc.Verified[i] = parser.VerificationEvent{By: v.By, At: v.At}
+			}
+		}
+		if len(concept.Parameters) > 0 {
+			pc.Parameters = make([]parser.Parameter, len(concept.Parameters))
+			for i, p := range concept.Parameters {
+				pc.Parameters[i] = parser.Parameter{Name: p.Name, Type: p.Type, Required: p.Required}
+			}
+		}
+		if concept.Executor != nil {
+			pc.Executor = &parser.ExecutorRef{Resource: concept.Executor.Resource, Receipt: concept.Executor.Receipt}
+		}
+		if concept.Attester != nil {
+			pc.Attester = &parser.AttesterRef{Resource: concept.Attester.Resource}
+		}
+		content, err := parser.SerializeConcept(pc, true)
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("serialize %s: %v", relPath, err))
 			continue

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/superops-team/okf/pkg/okf"
@@ -60,12 +61,14 @@ func loadBundleSilent(path string) (*okf.KnowledgeBundle, error) {
 }
 
 // Run starts the MCP server main loop.
+// Uses the MCP stdio transport framing: Content-Length headers (LSP-style).
+// Also accepts newline-delimited JSON for backward compatibility.
 func (s *Server) Run() error {
 	s.logger.Println("OKF MCP Server starting...")
 	s.logger.Printf("Registered tools: %d", len(s.tools.List()))
 
 	for {
-		line, err := s.reader.ReadString('\n')
+		data, err := s.readMessage()
 		if err != nil {
 			if err == io.EOF {
 				s.logger.Println("Client disconnected (EOF)")
@@ -74,15 +77,50 @@ func (s *Server) Run() error {
 			s.logger.Printf("Read error: %v", err)
 			return err
 		}
-
-		line = strings.TrimSpace(line)
-		if line == "" {
+		if len(data) == 0 {
 			continue
 		}
-
-		s.logger.Printf("Received: %s", truncate(line, 200))
-		s.handleMessage([]byte(line))
+		s.logger.Printf("Received: %s", truncate(string(data), 200))
+		s.handleMessage(data)
 	}
+}
+
+// readMessage reads one JSON-RPC message. Supports both Content-Length header
+// framing (per MCP spec) and newline-delimited JSON (for simple testing).
+func (s *Server) readMessage() ([]byte, error) {
+	line, err := s.reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	line = strings.TrimRight(line, "\r\n")
+
+	// Content-Length header framing (MCP standard)
+	if strings.HasPrefix(strings.ToLower(line), "content-length:") {
+		clStr := strings.TrimSpace(line[len("Content-Length:"):])
+		contentLen, perr := strconv.Atoi(clStr)
+		if perr != nil {
+			return nil, fmt.Errorf("invalid Content-Length: %s", clStr)
+		}
+		// Read remaining headers until empty line
+		for {
+			hdrLine, herr := s.reader.ReadString('\n')
+			if herr != nil {
+				return nil, herr
+			}
+			if strings.TrimSpace(hdrLine) == "" {
+				break
+			}
+		}
+		// Read exactly contentLen bytes
+		data := make([]byte, contentLen)
+		if _, ferr := io.ReadFull(s.reader, data); ferr != nil {
+			return nil, ferr
+		}
+		return data, nil
+	}
+
+	// Fallback: newline-delimited JSON (simple clients/testing)
+	return []byte(line), nil
 }
 
 func (s *Server) handleMessage(data []byte) {
@@ -334,9 +372,18 @@ func (s *Server) writeMessage(msg interface{}) {
 		s.logger.Printf("Failed to marshal message: %v", err)
 		return
 	}
-	data = append(data, '\n')
-	if _, err := s.writer.Write(data); err != nil {
+	// MCP stdio transport: Content-Length header framing (LSP-style)
+	var buf strings.Builder
+	buf.WriteString(fmt.Sprintf("Content-Length: %d\r\n", len(data)))
+	buf.WriteString("\r\n")
+	buf.Write(data)
+	if _, err := s.writer.Write([]byte(buf.String())); err != nil {
 		s.logger.Printf("Failed to write message: %v", err)
+		return
+	}
+	// Flush stdout to ensure message is sent promptly
+	if f, ok := s.writer.(interface{ Flush() error }); ok {
+		_ = f.Flush()
 	}
 	s.logger.Printf("Sent: %s", truncate(string(data), 200))
 }

--- a/pkg/okf/api.go
+++ b/pkg/okf/api.go
@@ -46,6 +46,11 @@ func LoadBundle(path string, opts *LoadOptions) (*KnowledgeBundle, error) {
 			return nil
 		}
 
+		// Skip reserved filenames (index.md, log.md) - they are not concept documents.
+		if parser.IsReservedFilename(filePath) {
+			return nil
+		}
+
 		if opts.FilterFunc != nil && !opts.FilterFunc(filePath, info) {
 			return nil
 		}
@@ -59,6 +64,7 @@ func LoadBundle(path string, opts *LoadOptions) (*KnowledgeBundle, error) {
 
 		pc, err := parser.ParseConcept(filePath)
 		if err != nil {
+			// Skip files that fail to parse but continue walking the bundle.
 			return nil
 		}
 

--- a/pkg/okf/import.go
+++ b/pkg/okf/import.go
@@ -227,26 +227,22 @@ func CollectFiles(path string) ([]string, error) {
 // =============================================================================
 
 // IsArchive returns true if the file is a supported archive format.
-// Detection is case-insensitive for compound extensions (.tar.gz, etc.)
-// but case-sensitive for simple extensions (.zip, .tar).
+// All extension checks are case-insensitive for user convenience.
 func IsArchive(path string) bool {
 	lower := strings.ToLower(path)
 
-	// Check for compound extensions (case-insensitive)
+	// Check for compound extensions
 	if strings.HasSuffix(lower, ".tar.gz") ||
 		strings.HasSuffix(lower, ".tar.bz2") ||
 		strings.HasSuffix(lower, ".tar.xz") {
 		return true
 	}
 
-	// Check for simple extensions (case-sensitive)
-	ext := filepath.Ext(path)
-	switch ext {
-	case ".zip", ".tar":
+	// Check for simple extensions (case-insensitive)
+	if strings.HasSuffix(lower, ".zip") || strings.HasSuffix(lower, ".tar") {
 		return true
-	default:
-		return false
 	}
+	return false
 }
 
 // ExtractArchive extracts an archive to the destination directory and returns the list of extracted markdown files.
@@ -354,7 +350,7 @@ func extractTarGz(archivePath, destDir string) ([]string, error) {
 	reader := io.Reader(file)
 
 	// Try to detect gzip compression
-	if strings.HasSuffix(archivePath, ".gz") {
+	if strings.HasSuffix(strings.ToLower(archivePath), ".gz") {
 		gzReader, err := gzip.NewReader(file)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
@@ -522,13 +518,14 @@ func ValidateConcept(content []byte, filePath string) (*Concept, error) {
 		return nil, fmt.Errorf("invalid OKF concept: %w", err)
 	}
 
-	// Validate required fields
+	// Validate required fields (v0.2: type is the only required field; title is optional)
 	if concept.Type == "" {
 		return nil, fmt.Errorf("missing required field: type")
 	}
 
+	// v0.2: derive title from filename if missing (spec §4.1)
 	if concept.Title == "" {
-		return nil, fmt.Errorf("missing required field: title")
+		concept.Title = titleFromImportPath(filePath)
 	}
 
 	return concept, nil
@@ -549,6 +546,16 @@ func ValidateOKFMarkdownCandidateFile(filePath string) error {
 		return fmt.Errorf("read concept file: %w", err)
 	}
 	return ValidateMarkdownFrontmatter(content)
+}
+
+// titleFromImportPath derives a human-readable title from a file path (v0.2 spec §4.1).
+func titleFromImportPath(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	if ext == ".md" {
+		base = base[:len(base)-len(ext)]
+	}
+	return strings.ReplaceAll(strings.ReplaceAll(base, "_", " "), "-", " ")
 }
 
 func ValidateMarkdownFrontmatter(content []byte) error {

--- a/pkg/okf/import_test.go
+++ b/pkg/okf/import_test.go
@@ -153,7 +153,7 @@ func TestIsArchive(t *testing.T) {
 		{"regular file", "file.md", false},
 		{"text file", "readme.txt", false},
 		{"no extension", "noextension", false},
-		{"uppercase ZIP", "archive.ZIP", false}, // case sensitive
+		{"uppercase ZIP", "archive.ZIP", true}, // case-insensitive (user convenience)
 	}
 
 	for _, tt := range tests {
@@ -576,7 +576,7 @@ Content here
 	}
 }
 
-// TestValidateConcept_MissingTitle tests validation fails for missing title
+// TestValidateConcept_MissingTitle tests that missing title is derived from filename (v0.2 spec §4.1)
 func TestValidateConcept_MissingTitle(t *testing.T) {
 	content := `---
 type: api
@@ -586,9 +586,12 @@ description: This is missing the title field
 Content here
 `
 
-	_, err := ValidateConcept([]byte(content), "test.md")
-	if err == nil {
-		t.Error("ValidateConcept() expected error for missing title, got nil")
+	concept, err := ValidateConcept([]byte(content), "my-concept.md")
+	if err != nil {
+		t.Fatalf("ValidateConcept() unexpected error for missing title (v0.2: optional): %v", err)
+	}
+	if concept.Title != "my concept" {
+		t.Errorf("ValidateConcept() expected title derived from filename 'my concept', got %q", concept.Title)
 	}
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -438,10 +438,13 @@ func findFrontmatterEnd(data []byte) int {
 	if !bytes.HasPrefix(data, []byte("---\n")) && !bytes.HasPrefix(data, []byte("---\r\n")) {
 		return -1
 	}
-	for i := 3; i < len(data)-3; i++ {
+	for i := 3; i <= len(data)-3; i++ {
 		if data[i] == '-' && data[i+1] == '-' && data[i+2] == '-' {
 			next := i + 3
-			if next < len(data) && (data[next] == '\n' || data[next] == '\r') {
+			if next >= len(data) {
+				return i
+			}
+			if data[next] == '\n' || data[next] == '\r' {
 				return i
 			}
 		}

--- a/test_mcp.py
+++ b/test_mcp.py
@@ -9,18 +9,41 @@ import os
 OKF_BIN = os.path.join(os.path.dirname(__file__), "okf-bin")
 BUNDLE_PATH = os.path.join(os.path.dirname(__file__), "docs", "knowledge")
 
+def _read_headers(proc):
+    """Read MCP headers until empty line, return Content-Length."""
+    content_length = 0
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            return None
+        line = line.strip()
+        if not line:
+            break
+        if line.lower().startswith("content-length:"):
+            try:
+                content_length = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                return None
+    return content_length
+
 def send_msg(proc, msg):
-    """Send a JSON-RPC message to the MCP server."""
-    data = json.dumps(msg) + "\n"
-    proc.stdin.write(data)
+    """Send a JSON-RPC message using MCP Content-Length framing."""
+    body = json.dumps(msg)
+    header = f"Content-Length: {len(body)}\r\n\r\n"
+    proc.stdin.write(header + body)
     proc.stdin.flush()
 
 def recv_msg(proc):
-    """Receive a JSON-RPC message from the MCP server."""
-    line = proc.stdout.readline()
-    if not line:
+    """Receive a JSON-RPC message using MCP Content-Length framing."""
+    content_length = _read_headers(proc)
+    if content_length is None:
         return None
-    return json.loads(line.strip())
+    if content_length == 0:
+        return None
+    body = proc.stdout.read(content_length)
+    if not body:
+        return None
+    return json.loads(body)
 
 def rpc_call(proc, method, params=None, msg_id=1):
     """Make a JSON-RPC call and return the result."""


### PR DESCRIPTION
## Summary

This PR applies fixes identified during a two-round code review of the recent PR #5 (v0.2 upgrade) and PR #6 (MCP server) merges.

### Fixes

**Parser (boundary bug):**
- `findFrontmatterEnd` had an off-by-one loop bound (`i < len(data)-3` → `i <= len(data)-3`) and did not accept closing `---` at EOF without trailing newline, causing valid markdown files without trailing newlines to fail frontmatter parsing.

**v0.2 spec conformance:**
- `ValidateConcept` still enforced title as required, contradicting v0.2 spec §4.1 where title is optional. Fixed to derive title from filename when missing (matching parser behavior).

**API error handling:**
- `LoadBundle` now explicitly skips reserved filenames (`index.md`, `log.md`) before calling `ParseConcept`, making the skip logic explicit rather than relying on parse errors.

**Data loss in SaveKnowledgeBase (critical):**
- `SaveKnowledgeBase` only serialized v0.1 fields when writing concepts to disk, dropping all v0.2 fields (sources, generated, verified, status, stale_after, runtime, parameters, computation, executor, attester, filePath). Fixed to serialize the full v0.2 concept structure.

**MCP stdio transport protocol (critical):**
- The MCP server used newline-delimited JSON over stdio, but the MCP specification requires LSP-style `Content-Length:` header framing. Standard MCP clients (Claude Desktop, etc.) could not communicate with the server. Fixed to implement proper Content-Length framing for both reading and writing, with newline-delimited fallback for reading.
- Added stdout flush after writing responses to prevent buffering delays.

**Incremental update / delete (v0.2 compatibility):**
- After fixing v0.2 serialization, `removeKnowledgeFile` failed to recognize auto-generated concepts because `hasTrustedGeneratedMetadata` only checked the legacy `generated: true` boolean in CustomFields, but v0.2 concepts store generated info in the `Generated` struct. Fixed to accept both formats.

**Archive detection consistency:**
- `IsArchive` was case-sensitive for simple extensions (`.zip`, `.tar`) but case-insensitive for compound extensions (`.tar.gz`), while `ExtractArchive` internally used case-insensitive checks. Unified to fully case-insensitive detection.
- Fixed `.gz` suffix check in `extractTarGz` to also be case-insensitive.

**Tests:**
- Updated `TestValidateConcept_MissingTitle` to verify filename-derived title instead of expecting error.
- Updated `TestIsArchive/uppercase_ZIP` to expect `true` for case-insensitive detection.
- Updated `test_mcp.py` to use Content-Length framing matching the fixed MCP server.

### Verification
- `go build ./...` passes
- `go vet ./...` passes
- `go test ./...` all packages pass
